### PR TITLE
Streamline packet format

### DIFF
--- a/double/draft-ietf-perc-double.md
+++ b/double/draft-ietf-perc-double.md
@@ -144,7 +144,7 @@ steps:
 
 * Assign the key and salt values for the outer (hop-by-hop) algorithm
   to the second half of the key and salt for the double algorithm. The
-  first half of the key is revered to as the inner key while the
+  first half of the key is referred to as the inner key while the
   second out half is referred to as the outer key. When a key is used
   by a cryptographic algorithm, the salt used is the part of the salt
   generated with that key.
@@ -185,11 +185,9 @@ OHB = ?PT ?SEQ Config
 ~~~~~
 
 If present, the PT and SEQ parts of the OHB contain the original payload type
-and sequence number fields, respectively.  The E2EExtLen portion represents the
-number of octets in the RTP header extension (following the length field) that
-should receive E2E protection, as an unsigned integer in network byte order.
-The final octet of the OHB specifies whether these fields are present, and the
-original value of the marker bit (if necessary):
+and sequence number fields, respectively. The final octet of the OHB specifies
+whether these fields are present, and the original value of the marker bit (if
+necessary):
 
 {align="left"}
 ~~~~~
@@ -285,7 +283,7 @@ packet, modifies the packet, updates the OHB with any modifications
 not already present in the OHB, and re-encrypts the packet using the
 cryptographic using the outer (hop-by-hop) key.
 
-* Apply the outer (bop-by-hop) cryptographic algorithm to decrypt the
+* Apply the outer (hop-by-hop) cryptographic algorithm to decrypt the
   packet.  If decrypting RTP header extensions hop-by-hop, then
   [@!RFC6904] MUST be used.  Note that the RTP payload produced by this
   decryption operation contains the original encrypted payload with the tag
@@ -300,8 +298,7 @@ cryptographic using the outer (hop-by-hop) key.
   the OHB.
 
 * If the Media Distributor resets a parameter to its original value,
-  it MAY drop it from the OHB as long as there are no other header
-  extensions following the OHB. Note that this might result in a
+  it MAY drop it from the OHB. Note that this might result in a
   decrease in the size of the OHB.
 
 * Apply the outer (hop-by-hop) cryptographic algorithm to the packet. If the RTP Sequence
@@ -362,7 +359,6 @@ If any of the following RTP headers extensions are found in the outer
 SRTP packet, they MAY be used:
 
 * Mixer-to-client audio level indicators (See [@RFC6465])
-
 
 # RTCP Operations
 

--- a/double/draft-ietf-perc-double.md
+++ b/double/draft-ietf-perc-double.md
@@ -200,6 +200,7 @@ marker bit (if necessary):
 * Q: SEQ is present
 * M: Marker bit is present
 * B: Value of marker bit
+* R: Reserved, MUST be set to 0
 
 In particular, an all-zero OHB config octet (0x00) indicates that there have
 been no modifications from the original header.

--- a/double/draft-ietf-perc-double.md
+++ b/double/draft-ietf-perc-double.md
@@ -114,7 +114,7 @@ Terms used throughout this document include:
 * hop-by-hop: meaning the link from the endpoint to or from the
   Media Distributor.
 
-* OHB: Original Header Block is an RTP header extension that contains
+* OHB: Original Header Block is an octet string that contains
   the original values from the RTP header that might have been changed
   by a Media Distributor.
 
@@ -145,7 +145,7 @@ steps:
 * Assign the key and salt values for the outer (hop-by-hop) algorithm
   to the second half of the key and salt for the double algorithm. The
   first half of the key is referred to as the inner key while the
-  second out half is referred to as the outer key. When a key is used
+  second half is referred to as the outer key. When a key is used
   by a cryptographic algorithm, the salt used is the part of the salt
   generated with that key.
   
@@ -185,9 +185,9 @@ OHB = ?PT ?SEQ Config
 ~~~~~
 
 If present, the PT and SEQ parts of the OHB contain the original payload type
-and sequence number fields, respectively. The final octet of the OHB specifies
-whether these fields are present, and the original value of the marker bit (if
-necessary):
+and sequence number fields, respectively. The final "config" octet of the OHB
+specifies whether these fields are present, and the original value of the
+marker bit (if necessary):
 
 {align="left"}
 ~~~~~
@@ -201,8 +201,8 @@ necessary):
 * M: Marker bit is present
 * B: Value of marker bit
 
-In particular, an all-zero OHB (0x00) indicates that there have been no
-modifications from the original header.
+In particular, an all-zero OHB config octet (0x00) indicates that there have
+been no modifications from the original header.
 
 # RTP Operations
 
@@ -227,11 +227,9 @@ O I |                               | RTP padding   | RTP pad count | I O
 O +>+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+<+ O
 O | |                    E2E authentication tag                     | | O
 O | +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+ | O
-O | ~                            OHB ...                            ~ | O
+O | |                            OHB ...                            | | O
 +>| +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+ |<+
-| | ~                     SRTP MKI (OPTIONAL)                       ~ | | 
-| | +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+ | |
-| | :                    HBH authentication tag                     : | | 
+| | |                    HBH authentication tag                     | | | 
 | | +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+ | |
 | |                                                                   | |
 | +- E2E Encrypted Portion               E2E Authenticated Portion ---+ |
@@ -259,7 +257,7 @@ key.  The processes is as follows:
 
 * Replace the header of the protected RTP packet with the header of the
   original packet, and append to the payload of the packet (1) the
-  authentication tag from the original transofmr, and (2) an empty OHB (0x00).
+  authentication tag from the original transform, and (2) an empty OHB (0x00).
   
 * Apply the outer cryptographic algorithm to the RTP packet.  If
   encrypting RTP header extensions hop-by-hop, then [@!RFC6904] MUST

--- a/double/draft-ietf-perc-double.md
+++ b/double/draft-ietf-perc-double.md
@@ -160,81 +160,86 @@ material for the outer (hop-by-hop) algorithm is to use
 
 # Original Header Block
 
-Any SRTP packet processed following these procedures MAY contain an
-Original Header Block (OHB) RTP header extension.
+The Original Header Block (OHB) contains the original values of any modified
+header fields.  In the encryption process, the OHB is appended to the RTP
+payload.  In the decryption process, the receiving endpoint uses it to
+reconstruct the original RTP header, so that it can pass the proper AAD value
+to the inner transform.
 
-The OHB contains the original values of any modified header fields and
-MUST be placed after any already-existing RTP header extensions.
-Placement of the OHB after any original header extensions is important
-so that the receiving endpoint can properly authenticate the original
-packet and any originally included RTP header extensions.  The
-receiving endpoint will authenticate the original packet by restoring
-the modified RTP header field values and header extensions.  It does
-this by copying the original values from the OHB and then removing the
-OHB extension and any other RTP header extensions that appear after
-the OHB extension.
+The OHB can reflect modifications to the following fields in an RTP header: the
+payload type, the sequence number, and the marker bit.  All other fields in the
+RTP header MUST remain unmodified; since the OHB cannot reflect their original
+values, the receiver will be unable to verify the E2E integrity of the packet.
 
-The Media Distributor is only permitted to modify the extension (X)
-bit, payload type (PT) field, and the RTP sequence number field.
-
-The OHB extension is either one octet in length, two octets in length,
-or three octets in length.  The length of the OHB indicates what data
-is contained in the extension.
-
-If the OHB is one octet in length, it contains the original PT field
-value.  In this case, the OHB has this form:
+The OHB has the following syntax (in ABNF):
 
 {align="left"}
 ~~~~~
- 0                   1
- 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5
-+-+-+-+-+-+-+-+-+---------------+
-|  ID   | len=0 |R|     PT      |
-+-+-+-+-+-+-+-+-+---------------+
+BYTE = %x00-FF
+
+PT = BYTE
+SEQ = 2BYTE
+Config = BYTE
+
+OHB = ?PT ?SEQ Config
 ~~~~~
 
-Note that "R" indicates a reserved bit that MUST be set to zero when
-sending a packet and ignored upon receipt. ID is the RTP Header
-Extension identifier negotiated in the SDP. 
-
-If the OHB is two octets in length, it contains the original RTP
-packet sequence number.  In this case, the OHB has this form:
+If present, the PT and SEQ parts of the OHB contain the original payload type
+and sequence number fields, respectively.  The E2EExtLen portion represents the
+number of octets in the RTP header extension (following the length field) that
+should receive E2E protection, as an unsigned integer in network byte order.
+The final octet of the OHB specifies whether these fields are present, and the
+original value of the marker bit (if necessary):
 
 {align="left"}
 ~~~~~
- 0                   1                   2
- 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3
-+-+-+-+-+-+-+-+-+-------------------------------+
-|  ID   | len=1 |        Sequence Number        |
-+-+-+-+-+-+-+-+-+-------------------------------+
++-+-+-+-+-+-+-+-+
+|R R R R B M P Q|
++-+-+-+-+-+-+-+-+
 ~~~~~
 
-If the OHB is three octets in length, it contains the original PT
-field value and RTP packet sequence number.  In this case, the OHB has
-this form:
+* P: PT is present
+* Q: SEQ is present
+* M: Marker bit is present
+* B: Value of marker bit
 
-{align="left"}
-~~~~~
- 0                   1                   2                   3
- 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 6 4 5 6 7 8 9 1
-+-+-+-+-+-+-+-+-+---------------+-------------------------------+
-|  ID   | len=2 |R|     PT      |        Sequence Number        |
-+-+-+-+-+-+-+-+-+---------------+-------------------------------+
-~~~~~
-
-If a Media Distributor modifies an original RTP header value, the
-Media Distributor MUST include the OHB extension to reflect the
-changed value, setting the X bit in the RTP header to 1 if no header
-extensions were originally present.  If another Media Distributor
-along the media path makes additional changes to the RTP header and
-any original value is already present in the OHB, the Media
-Distributor must extend the OHB by adding the changed value to the
-OHB.  To properly preserve original RTP header values, a Media
-Distributor MUST NOT change a value already present in the OHB
-extension.
+In particular, an all-zero OHB (0x00) indicates that there have been no
+modifications from the original header.
 
 # RTP Operations
 
+~~~~~
+       0                   1                   2                   3
+     0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
+    +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+<+<+
+    |V=2|P|X|  CC   |M|     PT      |       sequence number         | I O
+    +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+ I O
+    |                           timestamp                           | I O
+    +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+ I O
+    |           synchronization source (SSRC) identifier            | I O
+    +=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+=+ I O
+    |            contributing source (CSRC) identifiers             | I O
+    |                               ....                            | I O
+    +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+<+ O
+    |                    RTP extension (OPTIONAL) ...               | | O
++>+>+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+<+ O
+O I |                          payload  ...                         | I O
+O I |                               +-------------------------------+ I O
+O I |                               | RTP padding   | RTP pad count | I O
+O +>+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+<+ O
+O | |                    E2E authentication tag                     | | O
+O | +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+ | O
+O | ~                            OHB ...                            ~ | O
++>| +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+ |<+
+| | ~                     SRTP MKI (OPTIONAL)                       ~ | | 
+| | +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+ | |
+| | :                    HBH authentication tag                     : | | 
+| | +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+ | |
+| |                                                                   | |
+| +- E2E Encrypted Portion               E2E Authenticated Portion ---+ |
+|                                                                       |
++--- HBH Encrypted Portion               HBH Authenticated Portion -----+
+~~~~~
 
 ## Encrypting a Packet
 
@@ -245,20 +250,18 @@ key.  The processes is as follows:
 * Form an RTP packet.  If there are any header extensions, they MUST
   use [@!RFC5285].
 
-* If the endpoint wishes to insert header extensions that can be
-  modified by an Media Distributor, it MUST insert an OHB header
-  extension at the end of any header extensions protected end-to-end
-  (if any), then add any Media Distributor-modifiable header
-  extensions.  In other cases, the endpoint SHOULD still insert an OHB
-  header extension. The OHB MUST replicate the information found in the RTP
-  header following the application of the inner cryptographic
-  algorithm.  If not already set, the endpoint MUST set the X bit in
-  the RTP header to 1 when introducing the OHB extension.
+* Form a synthetic RTP packet with the following contents:
+  * Header: The RTP header of the original packet with the following
+    modifications:
+    * The X bit is set to zero
+    * The header is truncated to remove any extensions (12 + 4 * CC bytes)
+  * Payload: The RTP payload of the original packet
 
-* Apply the inner cryptographic algorithm to the RTP packet.  If 
-  encrypting RTP header extensions end-to-end, then [@!RFC6904] MUST 
-  be used when encrypting the RTP packet using the inner cryptographic 
-  key. 
+* Apply the inner cryptographic algorithm to the RTP packet.
+
+* Replace the header of the protected RTP packet with the header of the
+  original packet, and append to the payload of the packet (1) the
+  authentication tag from the original transofmr, and (2) an empty OHB (0x00).
   
 * Apply the outer cryptographic algorithm to the RTP packet.  If
   encrypting RTP header extensions hop-by-hop, then [@!RFC6904] MUST
@@ -284,7 +287,9 @@ cryptographic using the outer (hop-by-hop) key.
 
 * Apply the outer (bop-by-hop) cryptographic algorithm to decrypt the
   packet.  If decrypting RTP header extensions hop-by-hop, then
-  [@!RFC6904] MUST be used.
+  [@!RFC6904] MUST be used.  Note that the RTP payload produced by this
+  decryption operation contains the original encrypted payload with the tag
+  from the inner transofrm and the OHB appended.
 
 * Change any parts of the RTP packet that the relay wishes to change
   and are allowed to be changed. 
@@ -297,30 +302,7 @@ cryptographic using the outer (hop-by-hop) key.
 * If the Media Distributor resets a parameter to its original value,
   it MAY drop it from the OHB as long as there are no other header
   extensions following the OHB. Note that this might result in a
-  decrease in the size of the OHB.  It is also possible for the Media
-  Distributor to remove the OHB entirely if all parameters in the RTP
-  header are reset to their original values and no other header
-  extensions follow the OHB.  If the OHB is removed and no other
-  extension is present, the X bit in the RTP header MUST be set to 0.
-
-* The Media Distributor MUST NOT delete any header extensions before
-  the OHB, but MAY add, delete, or modify any that follow the OHB.
-
-    * If the Media Distributor adds any header extensions, it must
-      append them and it must maintain the order of the original
-      header extensions in the [@!RFC5285] block.
-    
-    * If the Media Distributor appends header extensions, then it MUST
-      add the OHB header extension (if not present), even if the OHB
-      merely replicates the original header field values, and append
-      the new extensions following the OHB.  The OHB serves as a
-      demarcation point between original RTP header extensions
-      introduced by the endpoint and those introduced by a Media
-      Distributor.
-    
-* The Media Distributor MAY modify any header extension appearing
-  after the OHB, but MUST NOT modify header extensions that are
-  present before the OHB.
+  decrease in the size of the OHB.
 
 * Apply the outer (hop-by-hop) cryptographic algorithm to the packet. If the RTP Sequence
   Number has been modified, SRTP processing happens as defined in SRTP
@@ -340,27 +322,26 @@ the inner (end-to-end) cryptographic key.
   header extensions hop-by-hop, then [@!RFC6904] MUST be used when
   decrypting the RTP packet using the outer cryptographic key.
 
+* Remove the inner authentication tag and the OHB from the end of the payload
+  of the outer SRTP packet.
+
 * Form a new synthetic SRTP packet with:
 
-  * Header = Received header, with header fields replaced with values
-    from OHB (if present).
+  * Header = Received header, with the following modifications:
+    * Header fields replaced with values from OHB (if any)
+    * The X bit is set to zero
+    * The header is truncated to remove any extensions (12 + 4 * CC bytes) 
 
-  * Insert all header extensions up to the OHB extension, but exclude
-    the OHB and any header extensions that follow the OHB.  If there
-    are no extensions remaining, then the X bit MUST bet set to 0.  If
-    there are extensions remaining, then the remaining extensions MUST
-    be padded to the first 32-bit boundary and the overall length of
-    the header extensions adjusted accordingly.
+  * Payload is the encrypted payload from the outer SRTP packet (after the
+    inner tag and OHB have been stripped).
 
-  * Payload is the encrypted payload from the outer SRTP packet.
+  * Authentication tag is the inner authentication tag from the outer SRTP
+    packet.
 
 * Apply the inner cryptographic algorithm to this synthetic SRTP
   packet.  Note if the RTP Sequence Number was changed by the Media
   Distributor, the synthetic packet has the original Sequence
   Number. If the integrity check does not pass, discard the packet.
-  If decrypting RTP header extensions end-to-end, then [@!RFC6904]
-  MUST be used when decrypting the RTP packet using the inner
-  cryptographic key.
 
 Once the packet has been successfully decrypted, the application needs
 to be careful about which information it uses to get the correct


### PR DESCRIPTION
This PR refactors the packet format in -double to be friendlier to implementations using double-unaware base transforms.  

* Move the OHB to the payload of the packet
* Arrange the inner tag, OHB, and outer tag so that appending / truncation are the only transormations needed in the encryption / decryption process
* Remove support for E2E-protected header extensions, so that implementations don't need header-processing logic